### PR TITLE
Update State.java

### DIFF
--- a/domain/src/main/java/br/com/ondetemjogo/domain/State.java
+++ b/domain/src/main/java/br/com/ondetemjogo/domain/State.java
@@ -3,6 +3,5 @@ package br.com.ondetemjogo.domain;
 public class State {
      private Long idState;
      private String name;
-     private String UF;
 }
 


### PR DESCRIPTION
Procurei bastante sobre a sigla de estados de outros países, e como existem países que não tem esse tipo de denominação com o estado. Resolvi deixar sem o campo sigla. Sendo assim a classe fica agora sem o atributo UF.